### PR TITLE
fixed attributes in hscript to work with virtual-dom

### DIFF
--- a/pug-vdom.js
+++ b/pug-vdom.js
@@ -71,13 +71,13 @@ Compiler.prototype.visitTag = function (node, parent) {
   var s = this.parentTagId
   this.parentTagId = id
   this.visitBlock(node.block)
-  this.addI(`var n${id} = h('${node.name}', {`)
+  this.addI(`var n${id} = h('${node.name}', {attributes:{`)
   var at = []
   node.attrs.forEach(function (attr) {
     at.push(`'${attr.name}': ${attr.val}`)
   })
   this.add(at.join(', '))
-  this.add(`}, n${id}Child)\r\n`)
+  this.add(`}}, n${id}Child)\r\n`)
   this.parentTagId = s
   this.addI(`n${s}Child.push(n${id})\r\n`)
 }


### PR DESCRIPTION
I am not sure if this varies depending on implementation and should thus be an option, but the most recent version of virtual-dom requires attributes to be placed in an attributes object rather than directly into hscript properties for them to render correctly.