### PR TITLE
Pull request for allowing multiple classes

### DIFF
--- a/pug-vdom.js
+++ b/pug-vdom.js
@@ -75,9 +75,17 @@ Compiler.prototype.visitTag = function (node, parent) {
   this.visitBlock(node.block)
   this.addI(`var n${id} = h('${node.name}', {attributes:{`)
   var at = []
+  var classes = []
   node.attrs.forEach(function (attr) {
-    at.push(`'${attr.name}': ${attr.val}`)
+    if(attr.name === 'class'){
+      classes = classes.concat(attr.val)
+    } else {
+      at.push(`'${attr.name}': ${attr.val}`)
+    }
   })
+  if(classes.length > 0){
+    at.push(`'class': ${classes.join('+\' \'+')}`)
+  }
   this.add(at.join(', '))
   this.add(`}}, n${id}Child)\r\n`)
   this.parentTagId = s


### PR DESCRIPTION
Hey batiste,

I've added a piece of code that solves the issue where in the code below,
both lines 'class1' is overwritten by 'class2' when converted.

.class1.class2(id='elemId')
.class1(id='elemId' class='.class2')

Thank you!
- CP*