### PR TITLE
Add vdom keys support

### DIFF
--- a/pug-vdom.js
+++ b/pug-vdom.js
@@ -76,6 +76,7 @@ Compiler.prototype.visitTag = function (node, parent) {
   this.add('var attrs = [' + node.attributeBlocks.join(',') + '].reduce(function(finalObj, currObj){ for (var propName in currObj) {finalObj[propName] = propName === "class" ? (finalObj[propName] ? finalObj[propName].concat(currObj[propName]) : [currObj[propName]]) : currObj[propName]; } return finalObj; }, {');
   var at = []
   var classes = []
+
   node.attrs.forEach(function (attr) {
     if(attr.name === 'class'){
       classes = classes.concat(attr.val)
@@ -89,8 +90,9 @@ Compiler.prototype.visitTag = function (node, parent) {
   this.add(at.join(', '))
   this.add('});')
   this.add('if (attrs.class) attrs.class = attrs.class.reduce(function(arr, currClass){ return arr.concat(currClass) }, []).join(" ");');
-
-  this.addI(`var n${id} = h('${node.name}', {attributes:attrs}, n${id}Child)\r\n`)
+  this.add('var properties = {attributes:attrs};');
+  this.add('if (attrs.id) properties.key = attrs.id;');
+  this.addI(`var n${id} = h('${node.name}', properties, n${id}Child)\r\n`)
   this.parentTagId = s
   this.addI(`n${s}Child.push(n${id})\r\n`)
 }


### PR DESCRIPTION
This adds support for VDOM's key feature, which allows for more efficient patches by reordering nodes instead of mutating them. For now, we just use the id attribute, as it's a convenient unique identifier. At some point, we may want to add an option to customize which attribute is used. 