### PR TITLE
Runtime class merge fix

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -7,15 +7,15 @@ function compileAttrs(attrs, attrBlocks) {
     var attrsObj = attrBlocks
         .reduce(function(finalObj, currObj) {
             for (var propName in currObj) {
-                finalObj[propName] = finalObj[propName] ? finalObj[propName].concat(currObj[propName]) : [currObj[propName]];
+                finalObj[propName] = finalObj[propName] ? finalObj[propName].concat(currObj[propName]) : [].concat(currObj[propName]);
             }
             return finalObj;
         }, attrs.reduce(function(finalObj, attr) {
             var val = attr.val;
-            finalObj[attr.name] = finalObj[attr.name] ? finalObj[attr.name].concat(val) : [val]
+            finalObj[attr.name] = finalObj[attr.name] ? finalObj[attr.name].concat(val) : [].concat(val)
             return finalObj;
         }, {}));
-
+    
     for (var propName in attrsObj) {
         attrsObj[propName] = mergeAttrs[propName] ? attrsObj[propName].join(' ') : attrsObj[propName].pop();
     }


### PR DESCRIPTION
In some cases, classes would be rendered with commas as separators. This addresses that issue.