### PR TITLE
Improve locals exposure performance

### DIFF
--- a/pug-vdom.js
+++ b/pug-vdom.js
@@ -49,6 +49,7 @@ Compiler.prototype.addI = function (str) {
 
 Compiler.prototype.compile = function () {
   this.bootstrap()
+  // console.log(this.buffer.join(''))
   return this.buffer.join('')
 }
 
@@ -60,7 +61,12 @@ Compiler.prototype.bootstrap = function () {
   // Bring all the variables from this into this scope
   this.addI(`var locals = context;\r\n`)
   this.addI(`var self = locals;\r\n`)
-  this.addI(`pugVDOMRuntime.exposeLocals(locals);\r\n`)
+  this.addI(`var remainingKeys = pugVDOMRuntime.exposeLocals(locals);\r\n`)
+  this.addI(`for (var prop in remainingKeys) {\r\n`)
+  this.indent++
+  this.addI(`eval('var ' + prop + ' =  locals.' + prop);\r\n`)
+  this.indent--
+  this.addI(`}\r\n`)
   this.addI(`var n0Child = []\r\n`)
   this.visit(this.ast)
   this.addI(`pugVDOMRuntime.deleteExposedLocals()\r\n`)

--- a/pug-vdom.js
+++ b/pug-vdom.js
@@ -60,9 +60,10 @@ Compiler.prototype.bootstrap = function () {
   // Bring all the variables from this into this scope
   this.addI(`var locals = context;\r\n`)
   this.addI(`var self = locals;\r\n`)
-  this.addI(`for (var prop in locals) eval('var ' + prop + ' =  locals.' + prop)\r\n`)
+  this.addI(`pugVDOMRuntime.exposeLocals(locals);\r\n`)
   this.addI(`var n0Child = []\r\n`)
   this.visit(this.ast)
+  this.addI(`pugVDOMRuntime.deleteExposedLocals()\r\n`)
   this.addI(`return n0Child\r\n`)
   this.indent--
   this.addI(`}\r\n`)

--- a/pug-vdom.js
+++ b/pug-vdom.js
@@ -49,7 +49,6 @@ Compiler.prototype.addI = function (str) {
 
 Compiler.prototype.compile = function () {
   this.bootstrap()
-  // console.log(this.buffer.join(''))
   return this.buffer.join('')
 }
 

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -1,9 +1,14 @@
 exports.compileAttrs = compileAttrs;
+exports.exposeLocals = exposeLocals;
+exports.deleteExposedLocals = deleteExposedLocals;
+
 global.pugVDOMRuntime = exports
 
 var flatten = function(arr) {
     return Array.prototype.concat.apply([], arr); 
 };
+
+var exposedLocals = {};
 
 function compileAttrs(attrs, attrBlocks) {
     var attrsObj = attrBlocks
@@ -38,4 +43,27 @@ function compileAttrs(attrs, attrBlocks) {
     }
 
     return attrsObj;
+}
+
+function exposeLocals(locals) {
+    return Object.keys(locals).forEach(function(prop) {
+        if (!(prop in window))  {
+            Object.defineProperty(window, prop, {
+                configurable: true, 
+                get: function() {
+                    return locals[prop]
+                }
+            });
+            exposedLocals[prop] = 1;
+        } else {
+            eval('var ' + prop + ' =  locals.' + prop);
+        }
+    })
+}
+
+function deleteExposedLocals() {
+    for (var prop in exposedLocals) {
+        delete window[prop];
+        delete exposedLocals[prop];
+    }
 }

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -4,6 +4,8 @@ exports.deleteExposedLocals = deleteExposedLocals;
 
 global.pugVDOMRuntime = exports
 
+if (!global) global = window;
+
 var flatten = function(arr) {
     return Array.prototype.concat.apply([], arr); 
 };
@@ -47,8 +49,8 @@ function compileAttrs(attrs, attrBlocks) {
 
 function exposeLocals(locals) {
     return Object.keys(locals).forEach(function(prop) {
-        if (!(prop in window))  {
-            Object.defineProperty(window, prop, {
+        if (!(prop in global))  {
+            Object.defineProperty(global, prop, {
                 configurable: true, 
                 get: function() {
                     return locals[prop]
@@ -63,7 +65,7 @@ function exposeLocals(locals) {
 
 function deleteExposedLocals() {
     for (var prop in exposedLocals) {
-        delete window[prop];
+        delete global[prop];
         delete exposedLocals[prop];
     }
 }

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -48,7 +48,7 @@ function compileAttrs(attrs, attrBlocks) {
 }
 
 function exposeLocals(locals) {
-    return Object.keys(locals).forEach(function(prop) {
+    return Object.keys(locals).reduce(function(acc, prop) {
         if (!(prop in global))  {
             Object.defineProperty(global, prop, {
                 configurable: true, 
@@ -58,9 +58,10 @@ function exposeLocals(locals) {
             });
             exposedLocals[prop] = 1;
         } else {
-            eval('var ' + prop + ' =  locals.' + prop);
+            acc[prop] = 1;
         }
-    })
+        return acc
+    }, {})
 }
 
 function deleteExposedLocals() {

--- a/test/basic.js
+++ b/test/basic.js
@@ -45,6 +45,10 @@ var pugText9 = `
     #{locals.myTagName}(data-foo="somevalue")
 `;
 
+var pugText10 = `
+.my-element(data-foo=myLocal)
+`
+
 function vdom (tagname, attrs, children) {
   return {tagName: tagname, attrs: attrs, children: children}
 }
@@ -184,5 +188,16 @@ describe('Compiler', function () {
 
     done()
   })
+
+  it('Compiles a template with locals namespace conflict', function (done) {
+    global.myLocal = 'wrong';
+    var vnodes = vDom.generateTemplateFunction(pugText10)({
+        myLocal: "foo"
+    }, h);
+    var vnode = vnodes[0];
+
+    assert.equal(vnode.properties.attributes['data-foo'], "foo")
+    done()
+})
 
 })


### PR DESCRIPTION
Previously, we were iterating over the entire locals object and evaluating each key. Performance testing indicated that this could get to be a significant bottleneck in larger apps with many keys in locals object. 

With this commit, we instead attempt to temporarily add a getter to global scope. If there is a name conflict, we fall back to the eval method, but in most cases this will significantly improve performance. 