### PR TITLE
Html support

### DIFF
--- a/pug-vdom.js
+++ b/pug-vdom.js
@@ -102,11 +102,8 @@ Compiler.prototype.visitTag = function (node, parent) {
 
 Compiler.prototype.visitInterpolatedTag = Compiler.prototype.visitTag;
 Compiler.prototype.visitText = function (node, parent) {
-  if (node.val[0] === '<') {
-    throw new Error(`Literal HTML cannot be supported properly yet (DomParser could do the trick): ${node.val}`)
-  }
   var s = JSON.stringify(node.val)
-  this.addI(`n${this.parentTagId}Child.push(${s})\r\n`)
+  this.addI(`n${this.parentTagId}Child.push(runtime.makeHtmlNode(${s}, ${node.mustEscape}))\r\n`)
 }
 
 Compiler.prototype.visitNamedBlock = function (node, parent) {
@@ -115,7 +112,7 @@ Compiler.prototype.visitNamedBlock = function (node, parent) {
 
 Compiler.prototype.visitCode = function (node, parent) {
   if (node.buffer) {
-    this.addI(`n${this.parentTagId}Child.push(${node.val})\r\n`)
+    this.addI(`n${this.parentTagId}Child.push(runtime.makeHtmlNode(${node.val}, ${node.mustEscape}))\r\n`)
   } else {
     this.addI(node.val + '\r\n')
   }

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -31,9 +31,9 @@ vDomHtmlWidget.prototype.init = function() {
     if (typeof this.html === 'string') {
         var div = document.createElement('div');
         if (this.escape) {
-            div.innerText = this.html.trim();
+            div.innerText = this.html;
         } else {
-            div.innerHTML = this.html.trim();
+            div.innerHTML = this.html;
         }
         return div.firstChild;
     }
@@ -44,7 +44,7 @@ function makeHtmlNode(html, escape=true) {
     if (isVnode(html)) {
         return html;
     }
-    return new vDomHtmlWidget(html, escape);
+    return new vDomHtmlWidget(html.trim(), escape);
 }
 
 function compileAttrs(attrs, attrBlocks) {

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -1,6 +1,9 @@
 exports.compileAttrs = compileAttrs;
 exports.exposeLocals = exposeLocals;
 exports.deleteExposedLocals = deleteExposedLocals;
+exports.makeHtmlNode = makeHtmlNode;
+
+var isVnode = require('virtual-dom/vnode/is-vnode');
 
 global.pugVDOMRuntime = exports
 
@@ -11,6 +14,43 @@ var flatten = function(arr) {
 };
 
 var exposedLocals = {};
+
+function vDomHtmlWidget(html, escape) {
+    this.html = html;
+    this.escape = escape;
+    this.type = 'Widget';
+}
+
+vDomHtmlWidget.prototype.update = function(previous) {
+    if (this.escape != previous.escape || this.html !== previous.html) {
+        return this.init()
+    }    
+}
+
+vDomHtmlWidget.prototype.renderContent = function(div) {
+    if (this.escape) {
+        div.innerText = this.html.trim();
+    } else {
+        div.innerHTML = this.html.trim();
+    }
+    return div;
+}
+
+vDomHtmlWidget.prototype.init = function() {
+    if (typeof this.html === 'string') {
+        var div = document.createElement('div');
+        this.renderContent(div)
+        return div.firstChild;
+    }
+    throw 'Unrecognized html input in pug template';
+}
+
+function makeHtmlNode(html, escape=true) {
+    if (isVnode(html)) {
+        return html;
+    }
+    return new vDomHtmlWidget(html, escape);
+}
 
 function compileAttrs(attrs, attrBlocks) {
     var attrsObj = attrBlocks

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -27,19 +27,14 @@ vDomHtmlWidget.prototype.update = function(previous) {
     }    
 }
 
-vDomHtmlWidget.prototype.renderContent = function(div) {
-    if (this.escape) {
-        div.innerText = this.html.trim();
-    } else {
-        div.innerHTML = this.html.trim();
-    }
-    return div;
-}
-
 vDomHtmlWidget.prototype.init = function() {
     if (typeof this.html === 'string') {
         var div = document.createElement('div');
-        this.renderContent(div)
+        if (this.escape) {
+            div.innerText = this.html.trim();
+        } else {
+            div.innerHTML = this.html.trim();
+        }
         return div.firstChild;
     }
     throw 'Unrecognized html input in pug template';

--- a/test/basic.js
+++ b/test/basic.js
@@ -49,6 +49,45 @@ var pugText10 = `
 .my-element(data-foo=myLocal)
 `
 
+var pugText11 = `
+div
+    p This text belongs to the paragraph tag.
+    br
+    .
+        This text belongs to the div tag.
+`
+
+var pugText12 = `
+div
+    | This text is #{"<div>plain</div>"}
+    .foo bar
+    | This text is #{"<div>plain</div>"}
+`
+
+var pugText13 = `
+div
+    | This text is !{"<div>html</div>"}
+    .foo bar
+    | This text is !{"<div>html</div>"}
+`
+
+var pugText14 = `
+div
+    | This text is #{locals.myText}
+    .foo bar
+    | This text is #{locals.myText}
+`
+
+var pugText15 = `
+div
+    | This text is !{locals.myText}
+    .foo bar
+    | This text is !{locals.myText}
+`
+
+
+
+
 function vdom (tagname, attrs, children) {
   return {tagName: tagname, attrs: attrs, children: children}
 }
@@ -198,6 +237,78 @@ describe('Compiler', function () {
 
     assert.equal(vnode.properties.attributes['data-foo'], "foo")
     done()
-})
+  })
+
+  it('Compiles a tag with dot block content.', function (done) {
+    var vnodes = vDom.generateTemplateFunction(pugText11)({}, h);
+    var vnode = vnodes[0];
+
+    assert.equal(vnode.children[2].type, 'Widget');
+    assert.equal(vnode.children[2].html, 'This text belongs to the div tag.');
+
+    done()
+  })
+
+  it('Compiles a tag with buffered escaped string content.', function (done) {
+    var vnodes = vDom.generateTemplateFunction(pugText12)({}, h);
+    var vnode = vnodes[0];
+
+    assert.equal(vnode.children[1].type, 'Widget');
+    assert.equal(vnode.children[1].escape, true);
+    assert.equal(vnode.children[1].html, "<div>plain</div>");
+    assert.notEqual(vnode.children[2].type, 'Widget');
+    assert.equal(vnode.children[4].type, 'Widget');
+    assert.equal(vnode.children[4].escape, true);
+    assert.equal(vnode.children[4].html, "<div>plain</div>");
+
+    done()
+  })
+
+  it('Compiles a tag with buffered non-escaped string content.', function (done) {
+    var vnodes = vDom.generateTemplateFunction(pugText13)({}, h);
+    var vnode = vnodes[0];
+
+    assert.equal(vnode.children[1].type, 'Widget');
+    assert.equal(vnode.children[1].escape, false);
+    assert.equal(vnode.children[1].html, "<div>html</div>");
+    assert.notEqual(vnode.children[2].type, 'Widget');
+    assert.equal(vnode.children[4].type, 'Widget');
+    assert.equal(vnode.children[4].escape, false);
+    assert.equal(vnode.children[4].html, "<div>html</div>");
+
+    done()
+  })
+
+  it('Compiles a tag with buffered escaped string content from local var.', function (done) {
+    var vnodes = vDom.generateTemplateFunction(pugText12)({ myText: 'plain' }, h);
+    var vnode = vnodes[0];
+
+    assert.equal(vnode.children[1].type, 'Widget');
+    assert.equal(vnode.children[1].escape, true);
+    assert.equal(vnode.children[1].html, "<div>plain</div>");
+    assert.notEqual(vnode.children[2].type, 'Widget');
+    assert.equal(vnode.children[4].type, 'Widget');
+    assert.equal(vnode.children[4].escape, true);
+    assert.equal(vnode.children[4].html, "<div>plain</div>");
+
+    done()
+  })
+
+
+
+  it('Compiles a tag with buffered non-escaped string content from local var.', function (done) {
+    var vnodes = vDom.generateTemplateFunction(pugText13)({ myText: 'html' }, h);
+    var vnode = vnodes[0];
+
+    assert.equal(vnode.children[1].type, 'Widget');
+    assert.equal(vnode.children[1].escape, false);
+    assert.equal(vnode.children[1].html, "<div>html</div>");
+    assert.notEqual(vnode.children[2].type, 'Widget');
+    assert.equal(vnode.children[4].type, 'Widget');
+    assert.equal(vnode.children[4].escape, false);
+    assert.equal(vnode.children[4].html, "<div>html</div>");
+
+    done()
+  })
 
 })

--- a/test/basic.js
+++ b/test/basic.js
@@ -280,7 +280,7 @@ describe('Compiler', function () {
   })
 
   it('Compiles a tag with buffered escaped string content from local var.', function (done) {
-    var vnodes = vDom.generateTemplateFunction(pugText12)({ myText: 'plain' }, h);
+    var vnodes = vDom.generateTemplateFunction(pugText14)({ myText: '<div>plain</div>' }, h);
     var vnode = vnodes[0];
 
     assert.equal(vnode.children[1].type, 'Widget');
@@ -297,7 +297,7 @@ describe('Compiler', function () {
 
 
   it('Compiles a tag with buffered non-escaped string content from local var.', function (done) {
-    var vnodes = vDom.generateTemplateFunction(pugText13)({ myText: 'html' }, h);
+    var vnodes = vDom.generateTemplateFunction(pugText15)({ myText: '<div>html</div>' }, h);
     var vnode = vnodes[0];
 
     assert.equal(vnode.children[1].type, 'Widget');


### PR DESCRIPTION
Addresses #15 

Note: multi-line literal html as demonstrated https://pugjs.org/language/plain-text.html#literal-html, is not currently supported and will be tricky to support. 

Note 2: this change assumes use of https://github.com/Matt-Esch/virtual-dom, making use of "widgets" as specified here https://github.com/Matt-Esch/virtual-dom/blob/master/docs/widget.md