### PR TITLE
Keep `this` unchanged when using `for...in` loop.

### DIFF
--- a/pug-vdom.js
+++ b/pug-vdom.js
@@ -157,7 +157,7 @@ Compiler.prototype.visitEach = function (node, parent) {
   this.addI(`var ${node.val} = ${tempVar}[${key}]\r\n`)
   this.visitBlock(node.block)
   this.indent--
-  this.addI(`})\r\n`)
+  this.addI(`}.bind(this))\r\n`)
 }
 
 Compiler.prototype.visitExtends = function (node, parent) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -94,6 +94,12 @@ div
         This text belongs to the div tag.
 `
 
+var pugText17 = `
+- this.words = ["myword"]
+for word in this.words
+  = word
+`
+
 var pugText18 = `
 each x in func()
   = x
@@ -239,6 +245,13 @@ describe('Compiler', function () {
     }, h);
 
     assert.equal(callCount, 1)
+    done()
+  })
+
+  it('Keeps `this` unchanged inside for...in loop', function (done) {
+    var vnodes = vDom.generateTemplateFunction(pugText17).call({}, {}, h);
+
+    assert.equal(vnodes[0], 'myword')
     done()
   })
 


### PR DESCRIPTION
Hi

I've noticed when using `for...in` loop, `this` is changed inside the loop due to the use of forEach.
The official implementation does intentionally preserve `this`.

https://github.com/pugjs/pug/blob/pug%402.0.3/packages/pug-code-gen/index.js#L767

Thank you!