### PR TITLE
each: only evaluate the expression once.

### DIFF
--- a/pug-vdom.js
+++ b/pug-vdom.js
@@ -148,10 +148,13 @@ Compiler.prototype.visitWhile = function (node) {
 }
 
 Compiler.prototype.visitEach = function (node, parent) {
+  var tempVar = 'v' + uid()
   var key = node.key || 'k' + uid()
-  this.addI(`Object.keys(${node.obj}).forEach(function (${key}) {\r\n`)
+
+  this.addI(`var ${tempVar} = ${node.obj}\r\n`)
+  this.addI(`Object.keys(${tempVar}).forEach(function (${key}) {\r\n`)
   this.indent++
-  this.addI(`var ${node.val} = ${node.obj}[${key}]\r\n`)
+  this.addI(`var ${node.val} = ${tempVar}[${key}]\r\n`)
   this.visitBlock(node.block)
   this.indent--
   this.addI(`})\r\n`)

--- a/test/basic.js
+++ b/test/basic.js
@@ -94,6 +94,10 @@ div
         This text belongs to the div tag.
 `
 
+var pugText18 = `
+each x in func()
+  = x
+`
 
 
 function vdom (tagname, attrs, children) {
@@ -221,6 +225,20 @@ describe('Compiler', function () {
     assert.equal(vnode.children.length, 4)
     assert.ok(vnode.children.every(child => child.tagName === 'LI'))
 
+    done()
+  })
+
+  it('Only evaluates expression once in for...in loop', function(done) {
+    var callCount = 0;
+    var vnodes = vDom.generateTemplateFunction(pugText18)({
+      func: function() {
+        callCount += 1;
+
+        return [1, 2];
+      }
+    }, h);
+
+    assert.equal(callCount, 1)
     done()
   })
 


### PR DESCRIPTION
Hi

When using the `each` loop, the expression part is evaluate upon each iteration.
This could be problematic if the expression's output changes each time, or if the expression is expensive to compute.

This patch saves the expression's result in a temporary variable, just like the official implementation.
https://github.com/pugjs/pug/blob/pug%402.0.3/packages/pug-code-gen/index.js#L731

Thank you!