### PR TITLE
Support block in code node.

### DIFF
--- a/pug-vdom.js
+++ b/pug-vdom.js
@@ -121,6 +121,14 @@ Compiler.prototype.visitCode = function (node, parent) {
   } else {
     this.addI(node.val + '\r\n')
   }
+
+  if(node.block){
+    this.addI('{\r\n')
+    this.indent++
+    this.visitBlock(node.block, node)
+    this.indent--
+    this.addI('}\r\n')
+  }
 }
 
 Compiler.prototype.visitConditional = function (node, parent) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -105,6 +105,10 @@ each x in func()
   = x
 `
 
+var pugText19 = `
+- for(var i=5; i<6; i++)
+  p= i
+`
 
 function vdom (tagname, attrs, children) {
   return {tagName: tagname, attrs: attrs, children: children}
@@ -357,6 +361,15 @@ describe('Compiler', function () {
     assert.equal(vnode.children[1].el.outerHTML, '<div>This is html</div>');
 
     delete global.document;
+
+    done()
+  })
+
+  it('Compiles code node with block', function(done) {
+    var vnodes = vDom.generateTemplateFunction(pugText19)({}, h);
+    var vnode = vnodes[0];
+
+    assert.equal(vnode.children[0].text, "5");
 
     done()
   })


### PR DESCRIPTION
Related to https://github.com/batiste/pug-vdom/issues/36

This patch adds support for using block with code node.

For example:
```pug
- for (var x = 0; x < 3; x++)
  li item
```

PUG documentation: https://pugjs.org/language/code.html

--

BTW, I notice some tests no longer pass in my environment.
```
  1) Compiler Compiles a tag with buffered non-escaped string content.:
     TypeError: Cannot read property 'outerHTML' of undefined
      at Context.<anonymous> (test/basic.js:314:39)

  2) Compiler Compiles a tag with buffered non-escaped string content from local var.:
     TypeError: Cannot read property 'outerHTML' of undefined
      at Context.<anonymous> (test/basic.js:345:39)

  3) Compiler Compiles a tag containing HTML text line.:
     TypeError: Cannot read property 'outerHTML' of undefined
      at Context.<anonymous> (test/basic.js:361:39)
```