### PR TITLE
Fix issue #42: locals cleared when executing a template inside another template

### DIFF
--- a/pug-vdom.js
+++ b/pug-vdom.js
@@ -60,7 +60,7 @@ Compiler.prototype.bootstrap = function () {
   // Bring all the variables from this into this scope
   this.addI(`var locals = context;\r\n`)
   this.addI(`var self = locals;\r\n`)
-  this.addI(`var remainingKeys = pugVDOMRuntime.exposeLocals(locals);\r\n`)
+  this.addI(`var remainingKeys = pugVDOMRuntime.enterLocalsScope(locals);\r\n`)
   this.addI(`for (var prop in remainingKeys) {\r\n`)
   this.indent++
   this.addI(`eval('var ' + prop + ' =  locals.' + prop);\r\n`)
@@ -68,7 +68,7 @@ Compiler.prototype.bootstrap = function () {
   this.addI(`}\r\n`)
   this.addI(`var n0Child = []\r\n`)
   this.visit(this.ast)
-  this.addI(`pugVDOMRuntime.deleteExposedLocals()\r\n`)
+  this.addI(`pugVDOMRuntime.exitLocalsScope()\r\n`)
   this.addI(`return n0Child\r\n`)
   this.indent--
   this.addI(`}\r\n`)

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -8,7 +8,7 @@ global.pugVDOMRuntime = exports
 if (!global) global = window;
 
 var flatten = function(arr) {
-    return Array.prototype.concat.apply([], arr); 
+    return Array.prototype.concat.apply([], arr);
 };
 
 var exposedLocals = {};
@@ -48,7 +48,7 @@ function replaceScript(script) {
     } else {
         newScript.textContent = script.textContent
     }
-    
+
     return newScript;
 }
 
@@ -57,7 +57,7 @@ function loadScripts(domNode) {
     if (domNode.tagName ===  'SCRIPT') {
         return replaceScript(domNode);
     }
-    
+
     Array.prototype.slice.call(domNode.querySelectorAll('script'))
         .forEach(function(script) {
             var newScript = replaceScript(script);
@@ -76,7 +76,7 @@ function makeHtmlNode(html) {
 
     var div = document.createElement('div');
     div.innerHTML = html;
-    
+
     return Array.prototype.slice.call(div.childNodes).map(function(child) {
         return new domNodeWidget(child)
     });
@@ -94,7 +94,7 @@ function compileAttrs(attrs, attrBlocks) {
             finalObj[attr.name] = finalObj[attr.name] ? finalObj[attr.name].concat(val) : [val];
             return finalObj;
         }, {}));
-    
+
     for (var propName in attrsObj) {
         if (propName === 'class') {
             attrsObj[propName] = flatten(attrsObj[propName].map(function(attrValue) {
@@ -108,7 +108,7 @@ function compileAttrs(attrs, attrBlocks) {
                     return classResult;
                 }
                 return attrValue;
-            })).join(' ');            
+            })).join(' ');
         } else {
             attrsObj[propName] = attrsObj[propName].pop();
         }
@@ -121,7 +121,7 @@ function exposeLocals(locals) {
     return Object.keys(locals).reduce(function(acc, prop) {
         if (!(prop in global))  {
             Object.defineProperty(global, prop, {
-                configurable: true, 
+                configurable: true,
                 get: function() {
                     return locals[prop]
                 }

--- a/test/basic.js
+++ b/test/basic.js
@@ -420,20 +420,21 @@ describe('Compiler', function () {
 
     done()
   })
-  
+
   it('Compiles a tag executing nested template.', function (done) {
     var window = (new JSDOM(`<!DOCTYPE html><html><body><div></div></body></html>`, {runScripts: "dangerously"})).window;
     global.document = window.document;
-    var inner = vDom.generateTemplateFunction(`= x`)
+    var inner = vDom.generateTemplateFunction(`= x + "1"`)
     var outer = vDom.generateTemplateFunction(`
-= inner({x: x})
-= x + "2"`);
-    
-    var vnode = outer({x: "a", inner})[0];
+div
+  = inner({x: x}, h)
+  = x + "2"`);
+
+    var vnode = outer({x: "a", inner}, h)[0];
     var patches = diff(h('div'), vnode);
     var el = patch(global.document.documentElement.querySelector('body').firstChild, patches);
 
-    assert.equal(el.outerHTML, '2 4');
+    assert.equal(el.outerHTML, '<div>a1a2</div>');
 
     done()
   })


### PR DESCRIPTION
Hi

This is my attempt on #42 .
Runtime function `exposeLocals()` and `deleteExposedLocals()` is now wrapped in `enterLocalsScope()` and `exitLocalsScope()`.

`enterLocalsScope()` will push exposed new locals to `exposedLocalsStack`, and remove them when `exitLocalsScope()` is called.

This change is backward compatible with generated modules from previous version by adding these alias.
```js
exports.exposeLocals = enterLocalsScope;
exports.deleteExposedLocals = exitLocalsScope;
```
Thanks!
